### PR TITLE
Implement `destroyOnClose` prop for Collapse and Accordion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2405,12 +2405,6 @@
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.149",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-      "dev": true
-    },
     "@types/node": {
       "version": "12.12.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "prop-types": "^15.7.2",
     "react-docgen-typescript": "^1.15.0",
     "react-docgen-typescript-loader": "3.4.0",
+    "react-dom": "16.12.0",
     "react-test-renderer": "^16.9.0",
     "ts-loader": "6.2.1",
     "typescript": "^3.6.4"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.3",
     "@types/jest": "^24.0.18",
-    "@types/lodash": "^4.14.144",
     "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.1",
     "@types/react-test-renderer": "^16.9.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@types/styled-components": "4.4.0",
     "framer-motion": "^1.6.12",
-    "lodash": "^4.17.15",
     "styled-components": "5.0.0-rc.2"
   },
   "peerDependencies": {

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -32,9 +32,6 @@ export interface AccordionProps {
   /** Determines which collapses should be active on initial render */
   defaultSelectedItems?: (string|number)[];
 
-  /** Determines which collapses should be active on initial render */
-  destroyOnClose?: boolean;
-
   /** Vertical gap between items */
   itemGap?: ItemGapType;
 
@@ -52,7 +49,6 @@ export const Accordion: AccordionFunctionComponent<AccordionProps> = ({
   classic,
   className,
   defaultSelectedItems,
-  destroyOnClose,
   itemGap,
   onChange,
   selectedItems: customSelectedItems
@@ -88,7 +84,6 @@ export const Accordion: AccordionFunctionComponent<AccordionProps> = ({
       value={{
         itemGap,
         selectedItems: customSelectedItems || selectedItems,
-        destroyOnClose,
         onChange: onCollapseChange
       }}
     >
@@ -104,7 +99,6 @@ Accordion.defaultProps = {
   classic: false,
   className: '',
   defaultSelectedItems: [],
-  destroyOnClose: false,
   itemGap: 20,
   onChange: undefined
 };

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -39,7 +39,7 @@ export interface AccordionProps {
   itemGap?: ItemGapType;
 
   /** Function to handle when collapse state changes */
-  onChange?: (selectedItems: ItemKeyType[]) => void;
+  onChange?: (key: ItemKeyType) => void;
 
   /** Determines which collapses should be active */
   selectedItems?: (string|number)[];
@@ -59,27 +59,31 @@ export const Accordion: AccordionFunctionComponent<AccordionProps> = ({
 }) => {
   const [selectedItems, setSelectedItems] = React.useState<(string|number)[]>(defaultSelectedItems || []);
 
-  function getClassicItems(key: ItemKeyType) {
-    return selectedItems.includes(key) ?
-      [] :
-      [key];
-  }
+  const onCollapseChange = React.useCallback((key: ItemKeyType) => {
+    // if there is no external control of items
+    if (customSelectedItems == null) {
+      function getItems(key: ItemKeyType) {
+        return selectedItems.includes(key) ?
+          selectedItems.filter((i: ItemKeyType) => i !== key) :
+          selectedItems.concat(key);
+      }
 
-  function getItems(key: ItemKeyType) {
-    return selectedItems.includes(key) ?
-      selectedItems.filter((i: ItemKeyType) => i !== key) :
-      selectedItems.concat(key);
-  }
+      function getClassicItems(key: ItemKeyType) {
+        return selectedItems.includes(key) ?
+          [] :
+          [key];
+      }
 
-  function onCollapseChange(key: ItemKeyType): void {
-    const newItems = classic ? getClassicItems(key) : getItems(key);
-
-    if (onChange) {
-      onChange(newItems);
+      const newItems = classic ? getClassicItems(key) : getItems(key);
+      setSelectedItems(newItems);
     }
 
-    setSelectedItems(newItems);
-  }
+    if (onChange) {
+      onChange(key);
+    }
+  }, [selectedItems, customSelectedItems, onChange, classic]);
+
+  console.log('render');
 
   return (
     <AccordionContext.Provider

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -83,8 +83,6 @@ export const Accordion: AccordionFunctionComponent<AccordionProps> = ({
     }
   }, [selectedItems, customSelectedItems, onChange, classic]);
 
-  console.log('render');
-
   return (
     <AccordionContext.Provider
       value={{

--- a/src/components/accordion/Accordion.tsx
+++ b/src/components/accordion/Accordion.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import * as _ from 'lodash';
 
 import {
   AccordionItem,
@@ -33,6 +32,9 @@ export interface AccordionProps {
   /** Determines which collapses should be active on initial render */
   defaultSelectedItems?: (string|number)[];
 
+  /** Determines which collapses should be active on initial render */
+  destroyOnClose?: boolean;
+
   /** Vertical gap between items */
   itemGap?: ItemGapType;
 
@@ -50,6 +52,7 @@ export const Accordion: AccordionFunctionComponent<AccordionProps> = ({
   classic,
   className,
   defaultSelectedItems,
+  destroyOnClose,
   itemGap,
   onChange,
   selectedItems: customSelectedItems
@@ -57,13 +60,13 @@ export const Accordion: AccordionFunctionComponent<AccordionProps> = ({
   const [selectedItems, setSelectedItems] = React.useState<(string|number)[]>(defaultSelectedItems || []);
 
   function getClassicItems(key: ItemKeyType) {
-    return _.includes(selectedItems, key) ?
+    return selectedItems.includes(key) ?
       [] :
       [key];
   }
 
   function getItems(key: ItemKeyType) {
-    return _.includes(selectedItems, key) ?
+    return selectedItems.includes(key) ?
       selectedItems.filter((i: ItemKeyType) => i !== key) :
       selectedItems.concat(key);
   }
@@ -83,6 +86,7 @@ export const Accordion: AccordionFunctionComponent<AccordionProps> = ({
       value={{
         itemGap,
         selectedItems: customSelectedItems || selectedItems,
+        destroyOnClose,
         onChange: onCollapseChange
       }}
     >
@@ -98,6 +102,7 @@ Accordion.defaultProps = {
   classic: false,
   className: '',
   defaultSelectedItems: [],
+  destroyOnClose: false,
   itemGap: 20,
   onChange: undefined
 };

--- a/src/components/accordion/__tests__/Accordion.spec.tsx
+++ b/src/components/accordion/__tests__/Accordion.spec.tsx
@@ -38,23 +38,22 @@ describe('Accordion', () => {
 
     // click items 1 and 2
     accordionItemHeader.at(0).simulate('click');
+    expect(mockOnChange).toBeCalledWith('1');
     accordionItemHeader.at(1).simulate('click');
+    expect(mockOnChange).toBeCalledWith('2');
 
-    expect(mockOnChange).toBeCalledWith(['1', '2']);
+    const accordionItem = wrapper.find('Collapse');
 
-    // close the first item and make sure its closed
-    accordionItemHeader.at(0).simulate('click');
-    expect(mockOnChange).toBeCalledWith(['2']);
+    expect(accordionItem.at(0).prop('active')).toBe(true);
+    expect(accordionItem.at(1).prop('active')).toBe(true);
 
     // cleanup
     wrapper.unmount();
   });
 
-  it('opens one clicked item at a time', () => {
-    const mockOnChange = jest.fn();
+  it('opens one item at a time', () => {
     const wrapper = mount(
       <Accordion
-        onChange={mockOnChange}
         classic
       >
         <Accordion.Item itemKey={'1'}>Accordion Item 1</Accordion.Item>
@@ -70,10 +69,10 @@ describe('Accordion', () => {
     accordionItemHeader.at(0).simulate('click');
     accordionItemHeader.at(1).simulate('click');
 
-    expect(mockOnChange).toBeCalledWith(['2']);
+    const accordionItem = wrapper.find('Collapse');
 
-    // cleanup
-    wrapper.unmount();
+    expect(accordionItem.at(0).prop('active')).toBe(false);
+    expect(accordionItem.at(1).prop('active')).toBe(true);
   });
 
   it('opens item 1 by default', () => {

--- a/src/components/accordion/context.ts
+++ b/src/components/accordion/context.ts
@@ -9,7 +9,6 @@ import {
 interface AccordionContext {
   itemGap?: ItemGapType;
   selectedItems: SelectedItemsType;
-  destroyOnClose?: boolean;
   onChange?: (itemKey: ItemKeyType) => void;
 }
 

--- a/src/components/accordion/context.ts
+++ b/src/components/accordion/context.ts
@@ -9,6 +9,7 @@ import {
 interface AccordionContext {
   itemGap?: ItemGapType;
   selectedItems: SelectedItemsType;
+  destroyOnClose?: boolean;
   onChange?: (itemKey: ItemKeyType) => void;
 }
 

--- a/src/components/accordion/stories/Accordion.stories.tsx
+++ b/src/components/accordion/stories/Accordion.stories.tsx
@@ -13,6 +13,7 @@ import {
 
 // @ts-ignore
 import mdx from './Accordion.mdx';
+import {ItemKeyType} from "../types";
 
 export default {
   title: 'Components/Accordion',
@@ -43,7 +44,6 @@ const AccordionContainer = styled.div`
 export const standard = () => (
   <AccordionContainer>
     <Accordion
-      defaultSelectedItems={['2']}
       classic={false}
       itemGap={20}
     >
@@ -83,9 +83,13 @@ export const external = () => {
   const itemKeys = ['1', '2' , '3'];
   const [selectedItems, setSelectedItems] = React.useState<any>([]);
 
-  const handleOnChange = React.useCallback((items) => {
+  const handleOnChange = React.useCallback((key) => {
+    const items = selectedItems.includes(key) ?
+      selectedItems.filter((i: ItemKeyType) => i !== key) :
+      selectedItems.concat(key);
+
     setSelectedItems(items)
-  }, []);
+  }, [selectedItems]);
 
   const handleOnClick = React.useCallback(() => {
     if (selectedItems.length === itemKeys.length) {

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -30,6 +30,9 @@ export interface CollapseProps {
   /** Determines if collapse should default to open */
   defaultActive?: boolean;
 
+  /** When Collapse closes the content component will be unmounted */
+  destroyOnClose?: boolean;
+
   /** Content to render in the header */
   header?: React.ReactNode;
 
@@ -52,6 +55,7 @@ export const Collapse: React.FunctionComponent<CollapseProps> = ({
   className,
   children,
   defaultActive,
+  destroyOnClose,
   header,
   itemKey,
   onChange
@@ -90,6 +94,7 @@ export const Collapse: React.FunctionComponent<CollapseProps> = ({
       </Header>
       <ContentContainer
         animate={isActive ? 'open' : 'closed'}
+        destroyOnClose={destroyOnClose}
         theme={theme}
       >
         <Content
@@ -107,6 +112,7 @@ Collapse.defaultProps = {
   children: '',
   className: '',
   defaultActive: undefined,
+  destroyOnClose: false,
   header: '',
   onChange: undefined,
   itemKey: ''

--- a/src/components/collapse/Content.tsx
+++ b/src/components/collapse/Content.tsx
@@ -11,6 +11,7 @@ import styled, {
 
 interface ContentContainerProps {
   animate: 'open' | 'closed';
+  destroyOnClose?: boolean;
   theme: any;
 }
 
@@ -18,7 +19,12 @@ interface ContentProps {
   theme: any;
 }
 
-export const ContentContainer: React.FunctionComponent<ContentContainerProps> = ({ children, animate, theme }) => {
+export const ContentContainer: React.FunctionComponent<ContentContainerProps> = ({
+  animate,
+  children,
+  destroyOnClose,
+  theme
+}) => {
   const variants = {
     closed: {
       height: 0
@@ -28,23 +34,28 @@ export const ContentContainer: React.FunctionComponent<ContentContainerProps> = 
     },
   };
 
+  const content = (
+    <motion.div
+      key="content"
+      style={{
+        overflow: 'hidden'
+      }}
+      initial="closed"
+      exit="closed"
+      animate={animate}
+      variants={variants}
+      transition={{ duration: theme.animations.time.veryFast, type: 'tween' }}
+    >
+      {children}
+    </motion.div>
+  );
+
   return (
     <AnimatePresence initial={false}>
-      {animate === 'open' && (
-        <motion.div
-          key="content"
-          style={{
-            overflow: 'hidden'
-          }}
-          initial="closed"
-          exit="closed"
-          animate={animate}
-          variants={variants}
-          transition={{ duration: theme.animations.time.veryFast, type: 'tween' }}
-        >
-          {children}
-        </motion.div>
-      )}
+      { destroyOnClose ?
+        animate === 'open' && content :
+        content
+      }
     </AnimatePresence>
   );
 };

--- a/src/components/collapse/__tests__/Collapse.spec.tsx
+++ b/src/components/collapse/__tests__/Collapse.spec.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 
 import {
-  mount,
+  mount, ReactWrapper,
   shallow
 } from "enzyme";
 
 import {
   Collapse
 } from '../Collapse';
+
+import {
+  act
+} from 'react-dom/test-utils';
 
 describe('Collapse', () => {
   it('renders without children', () => {
@@ -56,6 +60,56 @@ describe('Collapse', () => {
     );
 
     expect(wrapper.find('Header').prop('open')).toBe(true);
+  });
+
+  it('sets the destroyOnClose prop', () => {
+    const wrapper = shallow(
+      <Collapse
+        itemKey={'test'}
+        header={'Header'}
+        destroyOnClose
+      >
+        Content
+      </Collapse>
+    );
+
+   expect(wrapper.find('ContentContainer').prop('destroyOnClose')).toBe(true);
+  });
+
+  it('destroys content on close', async () => {
+    const wrapper = mount(
+      <Collapse
+        itemKey={'test'}
+        header={'Header'}
+        defaultActive
+        destroyOnClose
+      >
+        Content
+      </Collapse>
+    );
+
+    expect(wrapper.exists('Content')).toBe(true);
+
+    // creating a promise with a setTimeout so we can wait for the animation of the collapse
+    // closing to finish before checking the dom
+    const promise = new Promise<ReactWrapper<any>>((resolve) => {
+      wrapper.setProps({active: false});
+      wrapper.update();
+
+      // wait for the animation to finish
+      setTimeout(() => {
+        wrapper.update();
+        resolve(wrapper.find('ContentContainer'));
+      }, 200)
+    });
+
+    let contentContainer: ReactWrapper;
+    await act(async () => {
+      contentContainer = await promise;
+    });
+
+    // @ts-ignore
+    expect(contentContainer.exists('Content')).toBe(false);
   });
 
   it('calls onChange handler', () => {

--- a/src/components/collapse/stories/Collapse.mdx
+++ b/src/components/collapse/stories/Collapse.mdx
@@ -25,7 +25,9 @@ Setting `defaultActive` to `true` will have the `Collapse` start in the open sta
 <SectionTitle>Destory on Close</SectionTitle>
 
 Setting `destroyOnClose` to `true` will have the `Collapse` unmount the contents of the collapse when it is closed
-. See the console for logs of when the content is mounted and unmounted.
+. Especially useful for components that do not need to be persisted when the collapse closes. Provides a level of
+ performance along with cleaning up the DOM. See the console for logs of when the content is
+ mounted and unmounted.
 
 <Preview>
   <Story id="components-collapse--destroy" />

--- a/src/components/collapse/stories/Collapse.mdx
+++ b/src/components/collapse/stories/Collapse.mdx
@@ -22,6 +22,16 @@ Setting `defaultActive` to `true` will have the `Collapse` start in the open sta
   <Story id="components-collapse--open"/>
 </Preview>
 
+<SectionTitle>Destory on Close</SectionTitle>
+
+Setting `destroyOnClose` to `true` will have the `Collapse` unmount the contents of the collapse when it is closed
+. See the console for logs of when the content is mounted and unmounted.
+
+<Preview>
+  <Story id="components-collapse--destroy" />
+</Preview>
+
+
 <SectionTitle>Props</SectionTitle>
 <Props of={Collapse} />
 

--- a/src/components/collapse/stories/Collapse.stories.tsx
+++ b/src/components/collapse/stories/Collapse.stories.tsx
@@ -37,6 +37,18 @@ const CollapseContent = ({ children }: any) => (
   </StyledCollapseContent>
 );
 
+const TestContent = () => {
+  React.useEffect(() => {
+    console.log('mounted');
+
+    return () => console.log('unmounted');
+  }, []);
+
+  return (
+    <CollapseContent />
+  );
+};
+
 export const simple = () => (
   <Container>
     <Collapse
@@ -55,7 +67,19 @@ export const open = () => (
       defaultActive
       itemKey="default"
     >
-      <CollapseContent />
+      <TestContent />
+    </Collapse>
+  </Container>
+);
+
+export const destroy = () => (
+  <Container>
+    <Collapse
+      header="Click Me"
+      itemKey="default"
+      destroyOnClose
+    >
+      <TestContent />
     </Collapse>
   </Container>
 );


### PR DESCRIPTION
- `destroyOnClose` prop implemented which will unmount the content of the collapse when it is closed. Useful for content that doesnt need to be updated or persisted when the collapse is closed.
- Change the `onChange` callback of accordion to just return the `itemKey` that changed
- Removed lodash as a dependency
- Fixed bug in accordion external story that was causing double renders to happen.