### PR TITLE
Updating Peer Deps with '^'

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "styled-components": "5.0.1"
   },
   "peerDependencies": {
-    "react": "16.11.0",
-    "react-dom": "16.11.0",
-    "react-is": "16.11.0"
+    "react": "^16.11.0",
+    "react-dom": "^16.11.0",
+    "react-is": "^16.11.0"
   },
   "devDependencies": {
     "@babel/cli": "7.2.0",


### PR DESCRIPTION
- Avoiding the `unmet peer deps` when installed with a higher version of peer deps