### PR TITLE
Modifying workflows to publish to github packages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,13 +15,12 @@ jobs:
         with:
           node-version: '10.16'
           scope: '@rtkwlf'
+          registry-url: https://npm.pkg.github.com/
       - name: Install
         run: npm install
       - name: Build
         run: npm run build
-      - name: Configure .npmrc for publish
-        run: 'echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc'
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
-      - name: Publish to npm
+      - name: Publish to github packages
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/deploy_next.yml
+++ b/.github/workflows/deploy_next.yml
@@ -15,13 +15,12 @@ jobs:
         with:
           node-version: '10.16'
           scope: '@rtkwlf'
+          registry-url: https://npm.pkg.github.com/
       - name: Install
         run: npm install
       - name: Build
         run: npm run build
-      - name: Configure .npmrc for publish
-        run: 'echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc'
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
-      - name: Publish to npm
+      - name: Publish to github packages
         run: npm publish --access public --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/components/tabs/TabsItem.tsx
+++ b/src/components/tabs/TabsItem.tsx
@@ -90,6 +90,8 @@ export const TabsItem: React.FunctionComponent<TabsItemProps> = ({
     if (defaultSelectedItem === itemKey && tabItemRef.current !== null) {
       setSelectedItem();
     }
+    // we only need to run on initial mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // handles when the selected item changes
@@ -97,6 +99,8 @@ export const TabsItem: React.FunctionComponent<TabsItemProps> = ({
     if (selectedItem === itemKey && tabItemRef.current !== null) {
       setSelectedItem();
     }
+    // we only care when the selected item has changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedItem]);
 
   return (


### PR DESCRIPTION
- Due to the fact that we are using the same `@rtkwlf` scope for private packages in github packages we are going to start publishing this package to github instead of npm. 
- Stay tuned for further updates on what is required in order to install this package.