### PR TITLE
Fixing workflow to publish to npm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,8 @@ on:
       - '!v*-beta*'
 
 jobs:
-  release:
-    name: Release to Github Packages and NPM
+  release-github:
+    name: Release to Github Packages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -24,6 +24,19 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  release-npm:
+    name: Release to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.16'
+          scope: '@rtkwlf'
+      - name: Install
+        run: npm install
+      - name: Build
+        run: npm run build
       - name: Configure .npmrc for publish to npm
         run: 'echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc'
       - name: Publish to npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtkwlf/ui",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rtkwlf/ui",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "main": "dist/ui.cjs.js",
   "module": "dist/ui.es.js",
   "types": "dist/ui.d.ts",


### PR DESCRIPTION
- Repetitive because it seems that the `registry-url` takes precedence over the `.npmrc` registry config.