### PR TITLE
Add support for collapse footer

### DIFF
--- a/src/components/accordion/AccordionItem.tsx
+++ b/src/components/accordion/AccordionItem.tsx
@@ -31,6 +31,9 @@ export interface AccordionItemProps {
   /** Content to render in the header */
   header?: React.ReactNode;
 
+  /** Content to render in the footer */
+  footer?: React.ReactNode;
+
   /** Unique key to identify collapse. Used for Accordion */
   itemKey: string | number;
 

--- a/src/components/accordion/stories/Accordion.stories.tsx
+++ b/src/components/accordion/stories/Accordion.stories.tsx
@@ -38,7 +38,7 @@ const AccordionContainer = styled.div`
 export const standard = () => (
   <AccordionContainer>
     <Accordion classic={false} defaultExpandedItems={['1', '3']} itemGap={20}>
-      <Accordion.Item itemKey="1">
+      <Accordion.Item itemKey="1" footer={<Button>Submit</Button>}>
         <CollapseContent>
           <Input label={'First Name'} />
           <Input label={'Last Name'} />
@@ -109,7 +109,7 @@ export const external = () => {
         defaultExpandedItems={selectedItems}
         onChange={handleOnChange}
       >
-        <Accordion.Item itemKey={itemKeys[0]}>
+        <Accordion.Item itemKey={itemKeys[0]} footer={<div>A footer</div>}>
           <CollapseContent />
         </Accordion.Item>
         <Accordion.Item itemKey={itemKeys[1]} disabled>

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -136,7 +136,7 @@ export const Collapse: React.FunctionComponent<CollapseProps> = ({
         theme={theme}
       >
         <Content theme={theme}>
-          <ContentBody theme={theme} hasBorderRadius={!footer}>
+          <ContentBody theme={theme} hasFooter={!!footer}>
             {children}
           </ContentBody>
           {footer && <ContentFooter theme={theme}>{footer}</ContentFooter>}

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -4,7 +4,12 @@ import styled, { css } from 'styled-components';
 
 import Header from './Header';
 
-import { ContentContainer, Content } from './Content';
+import {
+  ContentContainer,
+  Content,
+  ContentBody,
+  ContentFooter,
+} from './Content';
 
 import { useAfterMountEffect } from '../../hooks';
 
@@ -35,6 +40,9 @@ export interface CollapseProps {
   /** Content to render in the header */
   header?: React.ReactNode;
 
+  /** Content to render in the footer */
+  footer?: React.ReactNode;
+
   /** Unique key to identify collapse. Used for Accordion */
   itemKey?: string | number;
 
@@ -56,6 +64,9 @@ const Container = styled.div<{ disabled?: boolean }>`
         border: 1px solid transparent;
         color: ${theme.collapseHeaderOpenColor};
       }
+      .rtk-collapse-content-footer {
+        background: ${theme.collapseContentFooterHoverColor};
+      }
     }
   `};
   }
@@ -70,6 +81,7 @@ export const Collapse: React.FunctionComponent<CollapseProps> = ({
   defaultExpanded,
   destroyOnClose,
   header,
+  footer,
   itemKey,
   onChange,
 }) => {
@@ -123,7 +135,12 @@ export const Collapse: React.FunctionComponent<CollapseProps> = ({
         destroyOnClose={destroyOnClose}
         theme={theme}
       >
-        <Content theme={theme}>{children}</Content>
+        <Content theme={theme}>
+          <ContentBody theme={theme} hasBorderRadius={!footer}>
+            {children}
+          </ContentBody>
+          {footer && <ContentFooter theme={theme}>{footer}</ContentFooter>}
+        </Content>
       </ContentContainer>
     </Container>
   );

--- a/src/components/collapse/Content.tsx
+++ b/src/components/collapse/Content.tsx
@@ -4,19 +4,15 @@ import { AnimatePresence, motion } from 'framer-motion';
 
 import styled, { css } from 'styled-components';
 
+import { GlobalTheme } from '../../theme/types';
+
 interface ContentContainerProps {
   animate: 'open' | 'closed';
   destroyOnClose?: boolean;
   theme: any;
 }
 
-interface ContentProps {
-  theme: any;
-}
-
-export const ContentContainer: React.FunctionComponent<any> = ({
-  onMouseEnter,
-  onMouseLeave,
+export const ContentContainer: React.FunctionComponent<ContentContainerProps> = ({
   animate,
   children,
   destroyOnClose,
@@ -34,8 +30,6 @@ export const ContentContainer: React.FunctionComponent<any> = ({
   const content = (
     <motion.div
       key="content"
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
       style={{
         overflow: 'hidden',
       }}
@@ -56,9 +50,67 @@ export const ContentContainer: React.FunctionComponent<any> = ({
   );
 };
 
+interface ContentBodyProps {
+  theme: GlobalTheme;
+  hasBorderRadius: boolean;
+}
+
+const StyledContentBody = styled.div<ContentBodyProps>`
+  ${({ theme, hasBorderRadius }) => css`
+    padding: ${theme.collapseContentPadding};
+    background: ${theme.collapseContentBackground};
+
+    ${hasBorderRadius &&
+      css`
+        border-radius: 0 0 ${theme.collapseBorderRadius}
+          ${theme.collapseBorderRadius};
+      `}}
+  `};
+`;
+
+export const ContentBody: React.FunctionComponent<ContentBodyProps> = props => {
+  const { children } = props;
+
+  return (
+    <StyledContentBody className={'rtk-collapse-content-body'} {...props}>
+      {children}
+    </StyledContentBody>
+  );
+};
+
+ContentBody.displayName = 'CollapseContentBody';
+
+interface ContentFooterProps {
+  theme: GlobalTheme;
+}
+
+const StyledFooter = styled.div<ContentFooterProps>`
+  ${({ theme }) => css`
+    background: ${theme.collapseContentBackground};
+    padding: ${theme.collapseContentPadding};
+    border-radius: 0 0 ${theme.collapseBorderRadius}
+      ${theme.collapseBorderRadius};
+  `};
+`;
+
+export const ContentFooter: React.FunctionComponent<ContentFooterProps> = props => {
+  const { children } = props;
+
+  return (
+    <StyledFooter className={'rtk-collapse-content-footer'} {...props}>
+      {children}
+    </StyledFooter>
+  );
+};
+
+ContentFooter.displayName = 'CollapseContentFooter';
+
+interface ContentProps {
+  theme: GlobalTheme;
+}
+
 const StyledContent = styled.div<ContentProps>`
   ${({ theme }) => css`
-    padding: ${theme.collapseContentPadding};
     background: ${theme.collapseContentBackground};
     border: ${theme.collapseBorder};
     border-color: ${theme.collapseBorderColor};

--- a/src/components/collapse/Content.tsx
+++ b/src/components/collapse/Content.tsx
@@ -52,15 +52,15 @@ export const ContentContainer: React.FunctionComponent<ContentContainerProps> = 
 
 interface ContentBodyProps {
   theme: GlobalTheme;
-  hasBorderRadius: boolean;
+  hasFooter: boolean;
 }
 
 const StyledContentBody = styled.div<ContentBodyProps>`
-  ${({ theme, hasBorderRadius }) => css`
+  ${({ theme, hasFooter }) => css`
     padding: ${theme.collapseContentPadding};
     background: ${theme.collapseContentBackground};
 
-    ${hasBorderRadius &&
+    ${!hasFooter &&
       css`
         border-radius: 0 0 ${theme.collapseBorderRadius}
           ${theme.collapseBorderRadius};

--- a/src/components/collapse/__tests__/Collapse.spec.tsx
+++ b/src/components/collapse/__tests__/Collapse.spec.tsx
@@ -47,10 +47,7 @@ describe('Collapse', () => {
     );
 
     expect(wrapper.find('CollapseContentFooter').children()).toHaveLength(1);
-    expect(wrapper.find('CollapseContentBody')).toHaveProp(
-      'hasFooter',
-      true
-    );
+    expect(wrapper.find('CollapseContentBody')).toHaveProp('hasFooter', true);
   });
 
   it('does not render footer and sets body radius', () => {
@@ -61,10 +58,7 @@ describe('Collapse', () => {
     );
 
     expect(wrapper.find('CollapseContentFooter')).not.toExist();
-    expect(wrapper.find('CollapseContentBody')).toHaveProp(
-      'hasFooter',
-      false
-    );
+    expect(wrapper.find('CollapseContentBody')).toHaveProp('hasFooter', false);
   });
 
   it('sets the defaultExpanded prop', () => {

--- a/src/components/collapse/__tests__/Collapse.spec.tsx
+++ b/src/components/collapse/__tests__/Collapse.spec.tsx
@@ -48,8 +48,8 @@ describe('Collapse', () => {
 
     expect(wrapper.find('CollapseContentFooter').children()).toHaveLength(1);
     expect(wrapper.find('CollapseContentBody')).toHaveProp(
-      'hasBorderRadius',
-      false
+      'hasFooter',
+      true
     );
   });
 
@@ -62,8 +62,8 @@ describe('Collapse', () => {
 
     expect(wrapper.find('CollapseContentFooter')).not.toExist();
     expect(wrapper.find('CollapseContentBody')).toHaveProp(
-      'hasBorderRadius',
-      true
+      'hasFooter',
+      false
     );
   });
 

--- a/src/components/collapse/__tests__/Collapse.spec.tsx
+++ b/src/components/collapse/__tests__/Collapse.spec.tsx
@@ -39,6 +39,34 @@ describe('Collapse', () => {
     expect(wrapper.find('CollapseHeader').children()).toHaveLength(1);
   });
 
+  it('renders footer and un-sets body radius', () => {
+    const wrapper = shallow(
+      <Collapse itemKey={'test'} header={'Header'} footer={'Footer'}>
+        Content
+      </Collapse>
+    );
+
+    expect(wrapper.find('CollapseContentFooter').children()).toHaveLength(1);
+    expect(wrapper.find('CollapseContentBody')).toHaveProp(
+      'hasBorderRadius',
+      false
+    );
+  });
+
+  it('does not render footer and sets body radius', () => {
+    const wrapper = shallow(
+      <Collapse itemKey={'test'} header={'Header'}>
+        Content
+      </Collapse>
+    );
+
+    expect(wrapper.find('CollapseContentFooter')).not.toExist();
+    expect(wrapper.find('CollapseContentBody')).toHaveProp(
+      'hasBorderRadius',
+      true
+    );
+  });
+
   it('sets the defaultExpanded prop', () => {
     const onChangeMock = jest.fn();
 

--- a/src/components/collapse/stories/Collapse.mdx
+++ b/src/components/collapse/stories/Collapse.mdx
@@ -41,5 +41,14 @@ If disabled, the current expanded state of the collapse will remain unchanged wh
   <Story id="components-collapse--disabled"/>
 </Preview>
 
+<SectionTitle>Footer</SectionTitle>
+
+If supplied, the `footer` will be rendered when the collapse is expanded. It also receives a unique background
+color when the collapse is hovered.
+
+<Preview>
+  <Story id="components-collapse--footer"/>
+</Preview>
+
 <SectionTitle>Props</SectionTitle>
 <Props of={Collapse} />

--- a/src/components/collapse/stories/Collapse.stories.tsx
+++ b/src/components/collapse/stories/Collapse.stories.tsx
@@ -21,21 +21,15 @@ const Container = styled.div`
   padding: 10px;
 `;
 
-const StyledCollapseContent = styled.div`
+const StyledCollapseContentBody = styled.div`
   height: 200px;
 `;
 
 const CollapseContent = ({ children }: any) => (
-  <StyledCollapseContent>{children}</StyledCollapseContent>
+  <StyledCollapseContentBody>{children}</StyledCollapseContentBody>
 );
 
 const TestContent = () => {
-  React.useEffect(() => {
-    console.log('mounted');
-
-    return () => console.log('unmounted');
-  }, []);
-
   return <CollapseContent />;
 };
 
@@ -67,6 +61,19 @@ export const disabled = () => (
   <Container>
     <Collapse header="Click Me" itemKey="default" disabled>
       <TestContent />
+    </Collapse>
+  </Container>
+);
+
+export const footer = () => (
+  <Container>
+    <Collapse
+      header="Click Me"
+      defaultExpanded
+      itemKey="default"
+      footer="Collapse Footer"
+    >
+      <CollapseContent>Collapse Body</CollapseContent>
     </Collapse>
   </Container>
 );

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -83,6 +83,7 @@ export const getDefaultTheme = (themeColors: Colors = colors): GlobalTheme => ({
   collapseBoxShadow: 'none',
   collapseContentPadding: '10px',
   collapseContentBackground: themeColors.primaryBackground,
+  collapseContentFooterHoverColor: themeColors.tertiaryBackground,
   collapseHeaderColor: themeColors.body,
   collapseHeaderBackground: themeColors.primaryBackground,
   collapseHeaderHoverBackground: themeColors.primary,

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -104,6 +104,7 @@ export interface GlobalTheme {
   collapseBoxShadow: string;
   collapseContentPadding: string;
   collapseContentBackground: string;
+  collapseContentFooterHoverColor: string;
   collapseHeaderColor: string;
   collapseHeaderBackground: string;
   collapseHeaderHoverBackground: string;


### PR DESCRIPTION
Add optional prop `footer` to Collapse and Accordion. 

Sample Accordion:
![Screen Shot 2020-05-20 at 4 59 16 PM](https://user-images.githubusercontent.com/31516445/82499779-4b8ab000-9ac0-11ea-889f-74150ec74e2b.png)
