### PR TITLE
handle edge case where a visible modal is unmounted

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -206,6 +206,12 @@ export const Modal: React.FunctionComponent<ModalProps> = ({
     } else {
       document.body.style.overflow = '';
     }
+
+    return () => {
+      // when a visible modal is abruptly unmounted (removed from DOM)
+      // we should revert the overflow style as well
+      document.body.style.overflow = '';
+    };
   }, [visible, checkFocus]);
 
   return (

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -206,13 +206,15 @@ export const Modal: React.FunctionComponent<ModalProps> = ({
     } else {
       document.body.style.overflow = '';
     }
+  }, [visible, checkFocus]);
 
+  React.useEffect(() => {
     return () => {
       // when a visible modal is abruptly unmounted (removed from DOM)
       // we should revert the overflow style as well
       document.body.style.overflow = '';
     };
-  }, [visible, checkFocus]);
+  }, []);
 
   return (
     <Portal>

--- a/src/components/modal/__tests__/Modal.spec.tsx
+++ b/src/components/modal/__tests__/Modal.spec.tsx
@@ -172,4 +172,16 @@ describe('Modal', () => {
     okButton.simulate('click');
     expect(defaultProps.onCancel).toHaveBeenCalled();
   });
+
+  it('should reset overflow when a visible modal is unmounted', () => {
+    const wrapper = mount(
+      <Modal {...defaultProps} visible>
+        {defaultContent}
+      </Modal>
+    );
+    expect(document.body.style.overflow).toBe('hidden');
+
+    wrapper.unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
 });


### PR DESCRIPTION
We noticed a bug where the screen is locked after a visible modal is directly unmounted (without going into invisible first).
While we'll update our usage to handle the visibility via prop instead of mounting/unmounting, I think it's still reasonable to handle this edge case in the ui kit. 🙂 