### PR TITLE
Badge Component

### DIFF
--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+
+import styled, { css } from 'styled-components';
+import { useTheme } from '../../hooks';
+import { GlobalTheme } from '../..';
+
+export interface BadgeProps {
+  /** className of the Badge component */
+  className?: string;
+  /** Right side content to show in the badge */
+  rightChildren?: React.ReactNode;
+  /** Optional left side content to show, typically an icon */
+  leftChildren?: React.ReactNode;
+  /** Color to use for the body of the badge */
+  backgroundColor?: string;
+  /** Color to use for the text of the badge. Use a color that contrasts with the bockground */
+  textColor?: string;
+}
+
+interface StyledBadgeProps {
+  backgroundColor?: string;
+  textColor?: string;
+  theme: GlobalTheme;
+}
+
+export const StyledBadge = styled.span<StyledBadgeProps>`
+  ${({ backgroundColor, textColor, theme }) => css`
+    padding: 4px 10px 5px 9px;
+    border-radius: 14px;
+    white-space: nowrap;
+    font-weight: bold;
+    border: 0px;
+    background: ${backgroundColor || theme.colors.primary};
+    color: ${textColor || theme.colors.white};
+  `};
+`;
+
+const SeparateContents = styled.span`
+  margin-right: 7px;
+`;
+
+export const Badge: React.FunctionComponent<BadgeProps> = ({
+  rightChildren,
+  leftChildren,
+  className,
+  ...rest
+}) => {
+  const theme = useTheme();
+
+  return (
+    <StyledBadge className={className} theme={theme} {...rest}>
+      {leftChildren && <SeparateContents>{leftChildren}</SeparateContents>}
+      {rightChildren}
+    </StyledBadge>
+  );
+};
+
+Badge.displayName = 'Badge';
+
+Badge.defaultProps = {
+  className: '',
+  rightChildren: null,
+  leftChildren: null,
+  backgroundColor: '',
+  textColor: '',
+};

--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -11,19 +11,19 @@ export type BadgeColorType =
   | 'orange'
   | 'purple'
   | 'blue'
-  | 'darkgray';
+  | 'gray';
 
 export interface BadgeProps {
   /** className of the Badge component */
   className?: string;
+  /** Color to use for the body of the badge */
+  backgroundColor?: BadgeColorType;
   /** Content to show in the badge */
   children?: React.ReactNode;
   /** Optional left side content to show, typically an icon, properly padded */
   leftChildren?: React.ReactNode;
   /** Optional right side content to show in the badge */
   rightChildren?: React.ReactNode;
-  /** Color to use for the body of the badge */
-  backgroundColor?: BadgeColorType;
 }
 
 interface StyledBadgeProps {
@@ -45,8 +45,8 @@ function getThemeColor(theme, color) {
       return theme.badgeBackgroundOrange;
     case 'purple':
       return theme.badgeBackgroundPurple;
-    case 'darkgray':
-      return theme.badgeBackgroundDarkGray;
+    case 'gray':
+      return theme.badgeBackgroundGray;
     default:
       return theme.badgeBackgroundGreen;
   }

--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -4,42 +4,82 @@ import styled, { css } from 'styled-components';
 import { useTheme } from '../../hooks';
 import { GlobalTheme } from '../..';
 
+export type BadgeColorType =
+  | 'green'
+  | 'red'
+  | 'yellow'
+  | 'orange'
+  | 'purple'
+  | 'blue'
+  | 'darkgray';
+
 export interface BadgeProps {
   /** className of the Badge component */
   className?: string;
-  /** Right side content to show in the badge */
-  rightChildren?: React.ReactNode;
-  /** Optional left side content to show, typically an icon */
+  /** Content to show in the badge */
+  children?: React.ReactNode;
+  /** Optional left side content to show, typically an icon, properly padded */
   leftChildren?: React.ReactNode;
+  /** Optional right side content to show in the badge */
+  rightChildren?: React.ReactNode;
   /** Color to use for the body of the badge */
-  backgroundColor?: string;
-  /** Color to use for the text of the badge. Use a color that contrasts with the bockground */
-  textColor?: string;
+  backgroundColor?: BadgeColorType;
 }
 
 interface StyledBadgeProps {
-  backgroundColor?: string;
-  textColor?: string;
+  backgroundColor?: BadgeColorType;
   theme: GlobalTheme;
 }
 
+function getThemeColor(theme, color) {
+  switch (color) {
+    case 'green':
+      return theme.badgeBackgroundGreen;
+    case 'red':
+      return theme.badgeBackgroundRed;
+    case 'blue':
+      return theme.badgeBackgroundBlue;
+    case 'yellow':
+      return theme.badgeBackgroundYellow;
+    case 'orange':
+      return theme.badgeBackgroundOrange;
+    case 'purple':
+      return theme.badgeBackgroundPurple;
+    case 'darkgray':
+      return theme.badgeBackgroundDarkGray;
+    default:
+      return theme.badgeBackgroundGreen;
+  }
+}
+
+function needsDarkText(theme, color) {
+  return color === 'yellow' || color === 'orange';
+}
+
 export const StyledBadge = styled.span<StyledBadgeProps>`
-  ${({ backgroundColor, textColor, theme }) => css`
-    padding: 4px 10px 5px 9px;
-    border-radius: 14px;
+  ${({ backgroundColor, theme }) => css`
+    padding: 4px 12px 4px 12px;
+    border-radius: 16px;
     white-space: nowrap;
     font-weight: bold;
     border: 0px;
-    background: ${backgroundColor || theme.colors.primary};
-    color: ${textColor || theme.colors.white};
+    color: ${needsDarkText(theme, backgroundColor)
+      ? theme.badgeTextColorDark
+      : theme.badgeTextColorLight};
+    background: ${getThemeColor(theme, backgroundColor)};
   `};
 `;
 
 const SeparateContents = styled.span`
-  margin-right: 7px;
+  margin-right: 4px;
+`;
+
+const SeparateRight = styled.span`
+  margin-left: 4px;
 `;
 
 export const Badge: React.FunctionComponent<BadgeProps> = ({
+  children,
   rightChildren,
   leftChildren,
   className,
@@ -50,7 +90,8 @@ export const Badge: React.FunctionComponent<BadgeProps> = ({
   return (
     <StyledBadge className={className} theme={theme} {...rest}>
       {leftChildren && <SeparateContents>{leftChildren}</SeparateContents>}
-      {rightChildren}
+      {children}
+      {rightChildren && <SeparateRight>{rightChildren}</SeparateRight>}
     </StyledBadge>
   );
 };
@@ -61,6 +102,5 @@ Badge.defaultProps = {
   className: '',
   rightChildren: null,
   leftChildren: null,
-  backgroundColor: '',
-  textColor: '',
+  backgroundColor: 'green',
 };

--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -58,7 +58,7 @@ function needsDarkText(theme, color) {
 
 export const StyledBadge = styled.span<StyledBadgeProps>`
   ${({ backgroundColor, theme }) => css`
-    padding: 4px 12px 4px 12px;
+    padding: 4px 10px 4px 9px;
     border-radius: 16px;
     white-space: nowrap;
     font-weight: bold;

--- a/src/components/badge/__tests__/Badge.spec.tsx
+++ b/src/components/badge/__tests__/Badge.spec.tsx
@@ -7,14 +7,14 @@ import { Icon } from '../../icons';
 
 describe('Badge', () => {
   it('renders', () => {
-    const wrapper = shallow(<Badge rightChildren="Test" />);
+    const wrapper = shallow(<Badge>Test</Badge>);
     expect(wrapper.find('Badge__StyledBadge')).toExist();
     expect(wrapper.find('Badge__StyledBadge').text()).toBe('Test');
   });
 
   it('can show an icon', () => {
     const exampleIcon = <Icon.Check />;
-    const wrapper = shallow(<Badge rightChildren={exampleIcon} />);
+    const wrapper = shallow(<Badge leftChildren={exampleIcon} />);
     expect(wrapper.find('Check')).toExist();
   });
 

--- a/src/components/badge/__tests__/Badge.spec.tsx
+++ b/src/components/badge/__tests__/Badge.spec.tsx
@@ -19,11 +19,11 @@ describe('Badge', () => {
   });
 
   it('can set the backgroundColor prop ', () => {
-    const wrapper = shallow(<Badge backgroundColor="#FFFFFF" />);
+    const wrapper = shallow(<Badge backgroundColor="green" />); // hello
 
     // @ts-ignore
     expect(wrapper.find('Badge__StyledBadge').prop('backgroundColor')).toBe(
-      '#FFFFFF'
+      'green'
     );
   });
 });

--- a/src/components/badge/__tests__/Badge.spec.tsx
+++ b/src/components/badge/__tests__/Badge.spec.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { shallow } from 'enzyme';
+
+import { Badge } from '../Badge';
+import { Icon } from '../../icons';
+
+describe('Badge', () => {
+  it('renders', () => {
+    const wrapper = shallow(<Badge rightChildren="Test" />);
+    expect(wrapper.find('Badge__StyledBadge')).toExist();
+    expect(wrapper.find('Badge__StyledBadge').text()).toBe('Test');
+  });
+
+  it('can show an icon', () => {
+    const exampleIcon = <Icon.Check />;
+    const wrapper = shallow(<Badge rightChildren={exampleIcon} />);
+    expect(wrapper.find('Check')).toExist();
+  });
+
+  it('can set the backgroundColor prop ', () => {
+    const wrapper = shallow(<Badge backgroundColor="#FFFFFF" />);
+
+    // @ts-ignore
+    expect(wrapper.find('Badge__StyledBadge').prop('backgroundColor')).toBe(
+      '#FFFFFF'
+    );
+  });
+});

--- a/src/components/badge/stories/Badge.mdx
+++ b/src/components/badge/stories/Badge.mdx
@@ -18,7 +18,7 @@ Note: you must manually set the color on any non-text `children` you supply (e.g
 
 <SectionTitle>Icons Only</SectionTitle>
 
-Flexible enough to be used with icons only
+Can be used with icons only
 
 <Preview>
   <Story id="components-badge--image"/>
@@ -27,7 +27,7 @@ Flexible enough to be used with icons only
 
 <SectionTitle>Text Only</SectionTitle>
 
-Centers the children if only the `rightChildren` property is set
+Centers the child node if no `rightChildren` or `leftChildren` are specified
 
 <Preview>
   <Story id="components-badge--text"/>

--- a/src/components/badge/stories/Badge.mdx
+++ b/src/components/badge/stories/Badge.mdx
@@ -1,0 +1,37 @@
+import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { Title, SectionTitle } from '../../../../.storybook/components';
+import { Badge } from '../Badge';
+
+<Title
+  title="Badge"
+  subtitle="Also known as a pill or label. Often used to indicate status."
+/>
+
+<SectionTitle>Simple</SectionTitle>
+
+Note: you must manually set the color on any non-text `children` you supply (e.g. icons)
+
+<Preview>
+  <Story id="components-badge--simple"/>
+</Preview>
+
+
+<SectionTitle>Icons Only</SectionTitle>
+
+Flexible enough to be used with icons only
+
+<Preview>
+  <Story id="components-badge--image"/>
+</Preview>
+
+
+<SectionTitle>Text Only</SectionTitle>
+
+Centers the children if only the `rightChildren` property is set
+
+<Preview>
+  <Story id="components-badge--text"/>
+</Preview>
+
+<SectionTitle>Badge Props</SectionTitle>
+<Props of={ Badge } />

--- a/src/components/badge/stories/Badge.stories.tsx
+++ b/src/components/badge/stories/Badge.stories.tsx
@@ -33,7 +33,7 @@ export default {
 export const simple = () => {
   const theme = useTheme();
   const exampleIcon = <Icon.Check color={theme.colors.white} />;
-  const exampleIconDark = <Icon.Check color={theme.colors.black} />;
+  const exampleIconDark = <Icon.Check color={theme.colors.label} />;
 
   return (
     <Container>
@@ -58,7 +58,7 @@ export const image = () => {
   const left = <Icon.Exclamation />;
   return (
     <Container>
-      <Badge leftChildren={left} backgroundColor="darkgray">
+      <Badge leftChildren={left} backgroundColor="gray">
         <Icon.InfoCircle />
       </Badge>
       <Spacer />

--- a/src/components/badge/stories/Badge.stories.tsx
+++ b/src/components/badge/stories/Badge.stories.tsx
@@ -8,6 +8,17 @@ import { Badge } from '../Badge';
 import mdx from './Badge.mdx';
 import { Icon } from '../../icons';
 import { useTheme } from '../../../hooks';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  margin-bottom: 10px;
+`;
+
+const Spacer = styled.span`
+  height: 1px;
+  padding: 5px;
+`;
 
 export default {
   title: 'Components/Badge',
@@ -22,29 +33,48 @@ export default {
 export const simple = () => {
   const theme = useTheme();
   const exampleIcon = <Icon.Check color={theme.colors.white} />;
-  return <Badge rightChildren="v10.42" leftChildren={exampleIcon} />;
+  const exampleIconDark = <Icon.Check color={theme.colors.black} />;
+
+  return (
+    <Container>
+      <Badge leftChildren={exampleIcon}>v10.42</Badge>
+      <Spacer />
+      <Badge rightChildren={exampleIcon} backgroundColor="red">
+        v10.42
+      </Badge>
+      <Spacer />
+      <Badge
+        leftChildren={exampleIconDark}
+        rightChildren={exampleIconDark}
+        backgroundColor="yellow"
+      >
+        v10.42
+      </Badge>
+    </Container>
+  );
 };
 
 export const image = () => {
   const left = <Icon.Exclamation />;
-  const right = <Icon.InfoCircle />;
   return (
-    <Badge
-      rightChildren={right}
-      leftChildren={left}
-      backgroundColor="#518042"
-      textColor="#FFFFFF"
-    />
+    <Container>
+      <Badge leftChildren={left} backgroundColor="darkgray">
+        <Icon.InfoCircle />
+      </Badge>
+      <Spacer />
+      <Badge backgroundColor="blue">
+        <Icon.InfoCircle />
+      </Badge>
+    </Container>
   );
 };
 
 export const text = () => {
-  const right = 'Text Only';
   return (
-    <Badge
-      rightChildren={right}
-      backgroundColor="#518042"
-      textColor="#FFFFFF"
-    />
+    <Container>
+      <Badge backgroundColor="purple">Text Only</Badge>
+      <Spacer />
+      <Badge backgroundColor="orange">?</Badge>
+    </Container>
   );
 };

--- a/src/components/badge/stories/Badge.stories.tsx
+++ b/src/components/badge/stories/Badge.stories.tsx
@@ -1,0 +1,50 @@
+/* eslint-disable */
+
+import * as React from 'react';
+
+import { Badge } from '../Badge';
+
+// @ts-ignore
+import mdx from './Badge.mdx';
+import { Icon } from '../../icons';
+import { useTheme } from '../../../hooks';
+
+export default {
+  title: 'Components/Badge',
+  component: Badge,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const simple = () => {
+  const theme = useTheme();
+  const exampleIcon = <Icon.Check color={theme.colors.white} />;
+  return <Badge rightChildren="v10.42" leftChildren={exampleIcon} />;
+};
+
+export const image = () => {
+  const left = <Icon.Exclamation />;
+  const right = <Icon.InfoCircle />;
+  return (
+    <Badge
+      rightChildren={right}
+      leftChildren={left}
+      backgroundColor="#518042"
+      textColor="#FFFFFF"
+    />
+  );
+};
+
+export const text = () => {
+  const right = 'Text Only';
+  return (
+    <Badge
+      rightChildren={right}
+      backgroundColor="#518042"
+      textColor="#FFFFFF"
+    />
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export {
   SizeType,
 } from './components/button/Button';
 
-export { Badge, BadgeProps } from './components/badge/Badge';
+export { Badge, BadgeProps, BadgeColorType } from './components/badge/Badge';
 
 export { Collapse, CollapseProps } from './components/collapse/Collapse';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ export {
   SizeType,
 } from './components/button/Button';
 
+export { Badge, BadgeProps } from './components/badge/Badge';
+
 export { Collapse, CollapseProps } from './components/collapse/Collapse';
 
 export { Floater, FloaterProps } from './components/floater/Floater';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -18,8 +18,8 @@ export const getDefaultTheme = (themeColors: Colors = colors): GlobalTheme => ({
   badgeBackgroundOrange: themeColors.orange,
   badgeBackgroundPurple: themeColors.purple,
   badgeBackgroundBlue: themeColors.blue,
-  badgeBackgroundDarkGray: themeColors.gray,
-  badgeTextColorDark: themeColors.black,
+  badgeBackgroundGray: themeColors.gray,
+  badgeTextColorDark: themeColors.label,
   badgeTextColorLight: themeColors.white,
 
   // ---- Button ---- //

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -11,6 +11,17 @@ export const getDefaultTheme = (themeColors: Colors = colors): GlobalTheme => ({
   animationTimeMedium: 0.5,
   animationTimeSlow: 1,
 
+  // ---- Badge ---- //
+  badgeBackgroundGreen: themeColors.green,
+  badgeBackgroundRed: themeColors.red,
+  badgeBackgroundYellow: themeColors.yellow,
+  badgeBackgroundOrange: themeColors.orange,
+  badgeBackgroundPurple: themeColors.purple,
+  badgeBackgroundBlue: themeColors.blue,
+  badgeBackgroundDarkGray: themeColors.gray,
+  badgeTextColorDark: themeColors.black,
+  badgeTextColorLight: themeColors.white,
+
   // ---- Button ---- //
   buttonBorderRadius: '4px',
   buttonPadding: '0px 15px',

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -36,6 +36,17 @@ export interface GlobalTheme {
   animationTimeMedium: number;
   animationTimeSlow: number;
 
+  // ---- Badge ---- //
+  badgeBackgroundGreen: string;
+  badgeBackgroundRed: string;
+  badgeBackgroundYellow: string;
+  badgeBackgroundOrange: string;
+  badgeBackgroundPurple: string;
+  badgeBackgroundBlue: string;
+  badgeBackgroundDarkGray: string;
+  badgeTextColorDark: string;
+  badgeTextColorLight: string;
+
   // ---- Button ---- //
   buttonBorderRadius: string;
   buttonPadding: string;

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -43,7 +43,7 @@ export interface GlobalTheme {
   badgeBackgroundOrange: string;
   badgeBackgroundPurple: string;
   badgeBackgroundBlue: string;
-  badgeBackgroundDarkGray: string;
+  badgeBackgroundGray: string;
   badgeTextColorDark: string;
   badgeTextColorLight: string;
 


### PR DESCRIPTION
## Description
- first pass at a Badge/Pill/Label component

## Testing
- unit tests
- displays in storybook
- was able to test it _in-situ_ by building then doing:
`    cp ~/dev/ui/dist/* ~/awn/pkg/nucleus/node_modules/\@rtkwlf/ui/dist/`
and restarting Nucleus

## Screenshots

In use (the top Badge is the existing component in Nucleus, size difference is because UI kit uses multiples of 4px for margins):

![Screen Shot 2020-07-23 at 11 57 29 AM](https://user-images.githubusercontent.com/37389035/88314214-9607f300-cce2-11ea-9739-f1a02f99b34e.png)


Doc page:

![Screen Shot 2020-07-23 at 11 55 05 AM](https://user-images.githubusercontent.com/37389035/88314264-a4eea580-cce2-11ea-9d07-8ff080ef120b.png)

