### PR TITLE
add notification component

### DIFF
--- a/src/components/notification/CloseIcon.tsx
+++ b/src/components/notification/CloseIcon.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+import styled from 'styled-components';
+
+import Times from '../icons/Times';
+
+import { Typography } from '../typography/Typography';
+
+const Container = styled.div`
+  cursor: pointer;
+  align-self: flex-start;
+`;
+
+interface CloseIconProps {
+  onClose?: () => void;
+}
+
+export const CloseIcon: React.FunctionComponent<CloseIconProps> = ({
+  onClose,
+}) => {
+  const handleClose = React.useCallback(() => {
+    if (onClose) {
+      onClose();
+    }
+  }, [onClose]);
+
+  return (
+    <Container onClick={handleClose}>
+      <Typography.Body>
+        <Times />
+      </Typography.Body>
+    </Container>
+  );
+};

--- a/src/components/notification/Notification.tsx
+++ b/src/components/notification/Notification.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import { useTheme } from '../../hooks/useTheme';
+
+import {
+  Container,
+  NotificationText,
+  NotificationTextContainer,
+  NotificationTitle,
+} from './StyledNotification';
+
+import { NotificationIcon } from '../notificationBox/NotificationIcon';
+import { CloseIcon } from './CloseIcon';
+import { NotificationBoxProps } from '../notificationBox/NotificationBox';
+
+export interface NotificationProps extends NotificationBoxProps {
+  /** the title text of the notification */
+  title: string;
+}
+
+export const Notification: React.FunctionComponent<NotificationProps> = ({
+  allowClose,
+  children,
+  className,
+  onClose,
+  notificationType,
+  title,
+}) => {
+  const theme = useTheme();
+
+  return (
+    <Container
+      className={`${className} rtk-notification`}
+      theme={theme}
+      notificationType={notificationType}
+    >
+      <NotificationIcon notificationType={notificationType} />
+      <NotificationTextContainer>
+        <NotificationTitle>{title}</NotificationTitle>
+        <NotificationText>{children}</NotificationText>
+      </NotificationTextContainer>
+      {allowClose && <CloseIcon onClose={onClose} />}
+    </Container>
+  );
+};
+
+Notification.defaultProps = {
+  allowClose: true,
+};
+
+Notification.displayName = 'Notification';

--- a/src/components/notification/Notification.tsx
+++ b/src/components/notification/Notification.tsx
@@ -11,11 +11,22 @@ import {
 
 import { NotificationIcon } from '../notificationBox/NotificationIcon';
 import { CloseIcon } from './CloseIcon';
-import { NotificationBoxProps } from '../notificationBox/NotificationBox';
 
-export interface NotificationProps extends NotificationBoxProps {
+export interface NotificationProps {
   /** the title text of the notification */
   title: string;
+
+  /** if true, the close icon will appear on the notification for interaction */
+  allowClose?: boolean;
+
+  /** className of the notification component */
+  className?: string;
+
+  /** Callback to be called when close is clicked */
+  onClose?: () => void;
+
+  /** Determines the intent of the notification for the user */
+  notificationType: 'default' | 'success' | 'error' | 'warning' | 'info';
 }
 
 export const Notification: React.FunctionComponent<NotificationProps> = ({

--- a/src/components/notification/StyledNotification.tsx
+++ b/src/components/notification/StyledNotification.tsx
@@ -12,9 +12,9 @@ interface ContainerProps {
 }
 
 export const Container = styled.div<ContainerProps>`
-  min-height: ${({ theme }) => theme.notificationBoxMinHeight};
+  min-height: ${({ theme }) => theme.notificationMinHeight};
 
-  max-width: ${({ theme }) => theme.notificationBoxMaxWidth};
+  max-width: ${({ theme }) => theme.notificationMaxWidth};
   width: 100%;
 
   display: flex;

--- a/src/components/notification/StyledNotification.tsx
+++ b/src/components/notification/StyledNotification.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+
+import styled, { css } from 'styled-components';
+
+import { GlobalTheme } from '../../theme/types';
+
+import { Typography } from '../typography/Typography';
+
+interface ContainerProps {
+  theme: GlobalTheme;
+  notificationType: 'default' | 'success' | 'error' | 'warning' | 'info';
+}
+
+export const Container = styled.div<ContainerProps>`
+  min-height: ${({ theme }) => theme.notificationBoxMinHeight};
+
+  max-width: ${({ theme }) => theme.notificationBoxMaxWidth};
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  
+  border-left: 8px solid;
+  
+    ${({ notificationType }) =>
+      notificationType === 'error' &&
+      css`
+        border-left-color: ${({ theme }) => theme.colors.red};
+      `}
+
+  ${({ notificationType }) =>
+    notificationType === 'warning' &&
+    css`
+      border-left-color: ${({ theme }) => theme.colors.yellow};
+    `}
+
+  ${({ notificationType }) =>
+    notificationType === 'success' &&
+    css`
+      border-left-color: ${({ theme }) => theme.colors.green};
+    `}
+
+  ${({ notificationType }) =>
+    notificationType === 'info' &&
+    css`
+      border-left-color: ${({ theme }) => theme.colors.blue};
+    `}
+  
+  ${({ notificationType }) =>
+    notificationType === 'default' &&
+    css`
+      border-left-color: ${({ theme }) => theme.colors.gray};
+    `}
+
+  box-shadow: ${({ theme }) => theme.notificationBoxBoxShadow};
+
+  padding: 16px;
+`;
+
+export const NotificationTextContainer = styled.div`
+  flex: 1;
+  padding: 0 16px;
+`;
+
+export const NotificationText = styled(Typography.Body)`
+  margin-top: 8px;
+  text-align: left;
+`;
+
+export const NotificationTitle: React.FunctionComponent = ({ children }) => (
+  <Typography.Title level={5}>{children}</Typography.Title>
+);

--- a/src/components/notification/__tests__/Notification.spec.tsx
+++ b/src/components/notification/__tests__/Notification.spec.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+import { mount, shallow } from 'enzyme';
+
+import { Notification } from '../Notification';
+
+describe('Notification', () => {
+  it('renders', () => {
+    const wrapper = shallow(
+      <Notification notificationType="info" title="title" />
+    );
+
+    expect(wrapper.exists('StyledNotification__Container')).toBe(true);
+    expect(wrapper.find('NotificationTitle').children()).toHaveText('title');
+  });
+
+  it('sets the notificationType prop', () => {
+    const wrapper = shallow(
+      <Notification notificationType="success" title="" />
+    );
+
+    expect(
+      wrapper.find('StyledNotification__Container').prop('notificationType')
+    ).toStrictEqual('success');
+  });
+
+  it('hides the close button', () => {
+    const wrapper = shallow(
+      <Notification notificationType="success" allowClose={false} title="" />
+    );
+
+    expect(wrapper.exists('CloseIcon')).toBe(false);
+  });
+
+  it('calls the onClose callback when closeIcon is clicked', () => {
+    const onCloseMock = jest.fn();
+
+    const wrapper = mount(
+      <Notification notificationType="error" onClose={onCloseMock} title="" />
+    );
+
+    wrapper.find('CloseIcon__Container').simulate('click');
+
+    expect(onCloseMock).toBeCalledTimes(1);
+  });
+});

--- a/src/components/notification/stories/Notification.mdx
+++ b/src/components/notification/stories/Notification.mdx
@@ -1,0 +1,17 @@
+import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import { Title, SectionTitle } from '../../../../.storybook/components';
+import { Notification } from '../Notification';
+
+<Title
+  title="Notification"
+  subtitle="Can be displayed anywhere on screen to inform the user of an action they just performed."
+/>
+
+<SectionTitle>Notification Types</SectionTitle>
+
+<Preview>
+  <Story id="components-notification--simple"/>
+</Preview>
+
+<SectionTitle>Notification Props</SectionTitle>
+<Props of={ Notification } />

--- a/src/components/notification/stories/Notification.stories.tsx
+++ b/src/components/notification/stories/Notification.stories.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable */
+
+import * as React from 'react';
+import styled from 'styled-components';
+
+import { Notification } from '../Notification';
+
+// @ts-ignore
+import mdx from './Notification.mdx';
+
+export default {
+  title: 'Components/Notification',
+  component: Notification,
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+const Spacer = styled.div`
+  height: 16px;
+`;
+
+export const simple = () => (
+  <React.Fragment>
+    <Notification notificationType="default" title="Title Text">
+      Insert message here.
+    </Notification>
+    <Spacer />
+    <Notification notificationType="warning" title="Warning">
+      Insert warning message here.
+    </Notification>
+    <Spacer />
+    <Notification notificationType="info" title="Info">
+      Insert info message here.
+    </Notification>
+    <Spacer />
+    <Notification notificationType="success" title="Success!">
+      Insert info success here.
+    </Notification>
+    <Spacer />
+    <Notification notificationType="error" title="Error">
+      Insert info error here.
+    </Notification>
+  </React.Fragment>
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,11 @@ export {
   NotificationBoxProps,
 } from './components/notificationBox/NotificationBox';
 
+export {
+  Notification,
+  NotificationProps,
+} from './components/notification/Notification';
+
 export { Panel, PanelProps } from './components/panel/Panel';
 
 export { Portal, PortalProps } from './components/portal/Portal';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -172,6 +172,11 @@ export const getDefaultTheme = (themeColors: Colors = colors): GlobalTheme => ({
   modalMinHeight: '200px',
   modalMinWidth: '520px',
 
+  // ---- Notification ---- //
+  notificationMinHeight: '46px',
+  notificationMaxWidth: '520px',
+  notificationBoxShadow: `0px 0px 4px ${rgba(themeColors.black, 0.2)}`,
+
   // ---- NotificationBox ---- //
   notificationBoxMinHeight: '46px',
   notificationBoxMaxWidth: '520px',

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -198,6 +198,11 @@ export interface GlobalTheme {
   modalMinWidth: string;
 
   // ---- NotificationBox ---- //
+  notificationMinHeight: string;
+  notificationMaxWidth: string;
+  notificationBoxShadow: string;
+
+  // ---- NotificationBox ---- //
   notificationBoxMinHeight: string;
   notificationBoxMaxWidth: string;
   notificationBoxErrorBackground: string;


### PR DESCRIPTION
Based on the `Notifications` in the component library designs. 
<img width="1044" alt="Screen Shot 2020-07-23 at 3 24 26 PM" src="https://user-images.githubusercontent.com/31516445/88330456-69aba100-ccf9-11ea-9c3c-90885cd9615f.png">

Basically `NotificationBox` except for stylings and that this has a title.
We can build our toast management API based on it later.