### PR TITLE
Adding ability to hide the droppad in the case of a preview

### DIFF
--- a/src/components/dropPad/DropPad.tsx
+++ b/src/components/dropPad/DropPad.tsx
@@ -21,6 +21,9 @@ export interface DropPadProps {
   /** files that have been dropped */
   files: DroppedFile[];
 
+  /** if true, the droppad will be hidden. Any dropped files will continue to be shown */
+  hideDroppad?: boolean;
+
   /** called after a file has been dropped on the pad */
   onDrop?: (files: File[]) => void;
 
@@ -65,6 +68,7 @@ const StyledPaperClip = styled(PaperClip)`
 
 export const DropPad: React.FunctionComponent<DropPadProps> = ({
   className,
+  hideDroppad,
   onDrop,
   onDelete,
   files,
@@ -91,19 +95,21 @@ export const DropPad: React.FunctionComponent<DropPadProps> = ({
 
   return (
     <Container className={`${className} rtk-drop-pad`}>
-      <DropPadContainer
-        {...getRootProps()}
-        isDragActive={isDragActive}
-        theme={theme}
-      >
-        <BorderContainer theme={theme} isDragActive={isDragActive}>
-          <input {...getInputProps()} />
-          <Typography.Body>
-            <StyledPaperClip />
-            <strong>Choose a file</strong>&nbsp;to attach or drag it here.
-          </Typography.Body>
-        </BorderContainer>
-      </DropPadContainer>
+      {!hideDroppad && (
+        <DropPadContainer
+          {...getRootProps()}
+          isDragActive={isDragActive}
+          theme={theme}
+        >
+          <BorderContainer theme={theme} isDragActive={isDragActive}>
+            <input {...getInputProps()} />
+            <Typography.Body>
+              <StyledPaperClip />
+              <strong>Choose a file</strong>&nbsp;to attach or drag it here.
+            </Typography.Body>
+          </BorderContainer>
+        </DropPadContainer>
+      )}
       {files.map(({ file, percentUploaded }, i) => {
         return (
           <DropPadFile

--- a/src/components/dropPad/__tests__/DropPad.spec.tsx
+++ b/src/components/dropPad/__tests__/DropPad.spec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import { DropPad } from '../DropPad';
 
@@ -9,5 +9,11 @@ describe('DropPad', () => {
     const wrapper = shallow(<DropPad files={[]} />);
 
     expect(wrapper.exists('DropPad__Container')).toBe(true);
+  });
+
+  it('hides the droppad when hideDroppad prop is true', () => {
+    const wrapper = mount(<DropPad files={[]} hideDroppad />);
+
+    expect(wrapper.exists('DropPad__DropPadContainer')).toBe(false);
   });
 });


### PR DESCRIPTION
- There are some usecases where we want to hide the droppad but still see the files that were attached