### PR TITLE
use typography label for input labels

### DIFF
--- a/src/components/formItem/FormItem.tsx
+++ b/src/components/formItem/FormItem.tsx
@@ -37,7 +37,7 @@ const Container = styled.div`
   position: relative;
 `;
 
-const Label = styled(Typography.Body)`
+const Label = styled(Typography.Label)`
   color: ${({ theme }) => theme.colors.black};
   font-size: 14px;
   font-weight: bold;

--- a/src/components/input/StyledInput.tsx
+++ b/src/components/input/StyledInput.tsx
@@ -17,7 +17,7 @@ export const Container = styled.div`
   width: 100%;
 `;
 
-export const Label = styled(Typography.Body)<{ required?: boolean }>`
+export const Label = styled(Typography.Label)<{ required?: boolean }>`
   ${({ theme, required }) => css`
     ${required &&
       css`


### PR DESCRIPTION
before
<img width="464" alt="Screen Shot 2020-08-18 at 1 14 22 PM" src="https://user-images.githubusercontent.com/31516445/90544173-c2cdef80-e154-11ea-8dc6-472ddb0bb4df.png">


after
<img width="543" alt="Screen Shot 2020-08-18 at 1 14 18 PM" src="https://user-images.githubusercontent.com/31516445/90544182-c5c8e000-e154-11ea-92b9-1ed357090115.png">



