### PR TITLE
Add 'regular' (outline) folder icon and minor style fixes

### DIFF
--- a/src/components/icons/FolderOutline.tsx
+++ b/src/components/icons/FolderOutline.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { faFolder } from '@fortawesome/free-regular-svg-icons/faFolder';
+
+import { IconProps } from './types';
+
+const FolderOutline: React.FunctionComponent<IconProps> = props => {
+  return <FontAwesomeIcon icon={faFolder} {...props} />;
+};
+
+export default FolderOutline;

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -19,6 +19,7 @@ import EyeSlash from './EyeSlash';
 import File from './File';
 import Folder from './Folder';
 import FolderOpen from './FolderOpen';
+import FolderOutline from './FolderOutline';
 import GlobeAmericas from './GlobeAmericas';
 import InfoCircle from './InfoCircle';
 import Loading from './Loading';
@@ -60,6 +61,7 @@ export const Icon = {
   File,
   Folder,
   FolderOpen,
+  FolderOutline,
   GlobeAmericas,
   InfoCircle,
   Loading,

--- a/src/components/table/Header.tsx
+++ b/src/components/table/Header.tsx
@@ -26,7 +26,7 @@ const TH = styled.th<{
     margin: 0;
     border-bottom: ${theme.tableHeadBorder};
     border-bottom-color: ${theme.tableHeadBorderColor};
-    width: ${`${width}%` || 'auto'};
+    width: ${width ? `${width}%` : 'auto'};
   `}
 `;
 

--- a/src/components/toggle/Toggle.tsx
+++ b/src/components/toggle/Toggle.tsx
@@ -34,6 +34,7 @@ const Container = styled.div<ContainerProps>`
   position: relative;
   height: ${({ theme }) => theme.toggleHeight};
   width: ${({ theme }) => theme.toggleWidth};
+  min-width: ${({ theme }) => theme.toggleWidth};
 
   background: ${({ theme, isOn }) =>
     isOn ? theme.toggleOnBackground : theme.toggleOffBackground};


### PR DESCRIPTION
Adds the "regular" vs "solid" folder icon.

Two minor style bugfixes:
- blank header width wasn't working
- toggle can end up getting squished if screen is narrow